### PR TITLE
Performance improvements of processing

### DIFF
--- a/src/duplicatesearcher/DuplicateSearcher.java
+++ b/src/duplicatesearcher/DuplicateSearcher.java
@@ -48,7 +48,7 @@ public class DuplicateSearcher
 		int processedIssueCount = 0;
 		
 		System.out.println("\nPROCESSING ISSUES");
-		Progress progress = new Progress(finished);
+		Progress progress = new Progress(finished, 5);
 		
 		while(iter.hasNext())
 		{

--- a/src/duplicatesearcher/DuplicateSearcher.java
+++ b/src/duplicatesearcher/DuplicateSearcher.java
@@ -84,7 +84,6 @@ public class DuplicateSearcher
 
 	public static void main(String[] args) throws ClassNotFoundException, IOException
 	{
-		final LocalDateTime start = LocalDateTime.now();
 
 		final RepositoryId repo = new RepositoryId(args[0], args[1]);
 		final IssueProcessor processor = new IssueProcessor(
@@ -96,15 +95,23 @@ public class DuplicateSearcher
 				ProcessingFlags.FILTER_BAD
 				);
 		DuplicateSearcher searcher = new DuplicateSearcher(repo, processor);
+		
+		final LocalDateTime startProcessing = LocalDateTime.now();
 		searcher.processIssues();
+		final LocalDateTime endProcessing = LocalDateTime.now();
+		final Duration elpasedTimeProcessing = Duration.between(startProcessing, endProcessing);
+		System.out.println("\nProcessing time: " + elpasedTimeProcessing);
+		
+		final LocalDateTime startAnalysis = endProcessing;
 		searcher.analyzeIssues(0.4);
-
-		final LocalDateTime end = LocalDateTime.now();
+		final LocalDateTime endAnalysis = LocalDateTime.now();
+		final Duration elpasedTimeAnalysis = Duration.between(startAnalysis, endAnalysis);
+		System.out.println("\nAnalysis time: " + elpasedTimeAnalysis);
 		
 		System.out.println("\n");
 		for(Duplicate d : searcher.getDuplicates())
 			System.out.println(d);
-		final Duration elpasedTime = Duration.between(start, end);
+		final Duration elpasedTime = Duration.between(startProcessing, endAnalysis);
 		System.out.println("Execution time:" + elpasedTime);
 		System.out.println("Found duplicates: " + searcher.getDuplicates().size());
 	}

--- a/src/duplicatesearcher/IssueProcessor.java
+++ b/src/duplicatesearcher/IssueProcessor.java
@@ -33,7 +33,7 @@ public class IssueProcessor
 	private final StopList stopListGitHub;
 	private final Stemmer stemmer = new Stemmer();
 	private final SpellCorrector spell;
-	private final Map<Token, Token> processedTokens = new HashMap<Token, Token>(2000);
+	private final Map<Token, Token> processedTokens = new HashMap<Token, Token>(120_000);
 
 	public IssueProcessor(EnumSet<ProcessingFlags> flags) throws IOException
 	{

--- a/src/duplicatesearcher/IssueProcessor.java
+++ b/src/duplicatesearcher/IssueProcessor.java
@@ -4,12 +4,19 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.naming.CommunicationException;
+
 import org.eclipse.egit.github.core.Comment;
 import org.eclipse.egit.github.core.Issue;
 
+import duplicatesearcher.analysis.frequency.TermFrequencyCounter;
 import duplicatesearcher.processing.Stemmer;
-import duplicatesearcher.processing.TokenProcessor;
 import duplicatesearcher.processing.spellcorrecting.SpellCorrector;
 import duplicatesearcher.processing.stoplists.StopList;
 
@@ -26,6 +33,7 @@ public class IssueProcessor
 	private final StopList stopListGitHub;
 	private final Stemmer stemmer = new Stemmer();
 	private final SpellCorrector spell;
+	private final Map<Token, Token> processedTokens = new HashMap<Token, Token>(2000);
 
 	public IssueProcessor(EnumSet<ProcessingFlags> flags) throws IOException
 	{
@@ -54,41 +62,74 @@ public class IssueProcessor
 		final String pullRequestError = "Pull requests should no longer exist in any data set. Remove this data set and download a new one.";
 		assert issue.getPullRequest().getHtmlUrl() == null: pullRequestError;
 		StrippedIssue strippedIssue = new StrippedIssue(issue, comments); 
-		strippedIssue = process(strippedIssue);
+		strippedIssue = processIssue(strippedIssue);
 		strippedIssue.createFrequencyCounterForAll();
 		return strippedIssue;
 	}
 
-	public StrippedIssue process(final StrippedIssue issue)
+	private StrippedIssue processIssue(StrippedIssue strippedIssue)
+	{
+		processFrequencyCounter(strippedIssue.getTitle());
+		processFrequencyCounter(strippedIssue.getBody());
+		processFrequencyCounter(strippedIssue.getComments());
+		processFrequencyCounter(strippedIssue.getLabels());
+		return strippedIssue;
+	}
+
+	private void processFrequencyCounter(TermFrequencyCounter counter)
+	{
+		Set<Token> iterationSet = new HashSet<Token>(counter.getTokens());
+		for(Token input : iterationSet)
+		{
+			if(input == null)
+				continue;
+			Token output;
+			
+			if(processedTokens.containsKey(input))
+			{
+				output = processedTokens.get(input);
+			}
+			else
+			{
+				output = process(input);
+				processedTokens.put(input, output);
+			}
+			
+			if(output == null)
+				counter.remove(input);
+			else if(!input.equals(output))
+				counter.change(input, output);
+		}
+	}
+
+	public Token process(Token token)
 	{
 		for(ProcessingFlags flag : flags)
-			applyProcess(issue, flag);
+		{
+			token = applyProcess(token, flag);
+			if(token == null)
+				return null;
+		}
 
-		return issue;
+		return token;
 	}
 
 
-	private void applyProcess(StrippedIssue issue, ProcessingFlags flag)
+	private Token applyProcess(Token token, ProcessingFlags flag)
 	{
 		switch(flag)
 		{
-			case PARSE_COMMENTS: issue.removeComments(); break;
-			case SPELL_CORRECTION: apply(issue, spell); break;
-			case STOP_LIST_COMMON: apply(issue, stopListCommon); break;
-			case STOP_LIST_GITHUB: apply(issue, stopListGitHub); break;
+			//case PARSE_COMMENTS: issue.removeComments(); break;
+			case SPELL_CORRECTION: return spell.process(token);
+			case STOP_LIST_COMMON: return stopListCommon.process(token);
+			case STOP_LIST_GITHUB: return stopListGitHub.process(token);
 			case STOP_LIST_TEMPLATE_DYNAMIC: System.out.println("Not implemented"); break;
 			case STOP_LIST_TEMPLATE_STATIC: System.out.println("Not implemented"); break;
 			case SYNONYMS: System.out.println("Not implemented"); break;
-			case STEMMING: apply(issue, stemmer); break;
-			case FILTER_BAD: issue.checkQuality(); break;
+			case STEMMING: return stemmer.process(token);
+			//case FILTER_BAD: issue.checkQuality(); break;
 		}
-	}
-	
-	private void apply(StrippedIssue issue, TokenProcessor processor)
-	{
-		processor.process(issue.getTitle());
-		processor.process(issue.getBody());
-		processor.process(issue.getComments());
+		return token;
 	}
 
 }

--- a/src/duplicatesearcher/StrippedIssue.java
+++ b/src/duplicatesearcher/StrippedIssue.java
@@ -45,6 +45,9 @@ public class StrippedIssue implements Serializable
 		this.closed = issue.getClosedAt() != null;
 		this.state = issue.getState();
 		
+		if(issue.getBody() == null)
+			issue.setBody("");
+		
 		CodeExtractor ce = new CodeExtractor(issue, comments);
 		Set<String> foundCode = ce.extractCode();
 		this.code = new TermFrequencyCounter();

--- a/src/duplicatesearcher/analysis/Analyzer.java
+++ b/src/duplicatesearcher/analysis/Analyzer.java
@@ -52,8 +52,8 @@ public class Analyzer
 		if(threshold < 0)
 			throw new IllegalArgumentException("Threshold cannot be negative");
 
-		final int finished = issues.size()*issues.size();
-		progress = new Progress(finished, 1000);
+		final int finished = (issues.size()*issues.size())/2;
+		progress = new Progress(finished, 5000);
 		
 		System.out.println("\nSEARCHING FOR DUPLICATES");
 		
@@ -72,10 +72,7 @@ public class Analyzer
 		Map<Token, Double> queryNormalized = new Normalizer(query).normalizeVector();
 
 		for(StrippedIssue issueInCollection : issues)
-		{
-			progress.increment();
-			progress.print();
-			
+		{			
 			if(issue.getNumber() <= issueInCollection.getNumber())
 				continue;
 			
@@ -86,6 +83,9 @@ public class Analyzer
 
 			if(similarity >= threshold)
 				createDuplicate(issue, issueInCollection, similarity, duplicates);
+			
+			progress.increment();
+			progress.print();
 		}
 
 		return duplicates;

--- a/src/duplicatesearcher/datastructures/BKtree.java
+++ b/src/duplicatesearcher/datastructures/BKtree.java
@@ -55,6 +55,9 @@ public class BKtree
 				values.put(distanceToRoot, new LinkedList<CharSequence>());
 			List<CharSequence> list = values.get(distanceToRoot);
 			list.add(word);
+			
+			if(distanceToRoot == 1)
+				return values;
 		}
 		
 		if(children.isEmpty())

--- a/src/duplicatesearcher/processing/Stemmer.java
+++ b/src/duplicatesearcher/processing/Stemmer.java
@@ -1,13 +1,8 @@
 package duplicatesearcher.processing;
 
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
-
 import org.tartarus.snowball.ext.englishStemmer;
 
 import duplicatesearcher.Token;
-import duplicatesearcher.analysis.frequency.TermFrequencyCounter;
 
 public class Stemmer extends englishStemmer implements TokenProcessor
 {
@@ -15,31 +10,17 @@ public class Stemmer extends englishStemmer implements TokenProcessor
 	{
 		return new Token(super.getCurrent());
 	}
-	
+
 	public void setCurrentToken(Token token)
 	{
 		super.setCurrent(token.toString());
 	}
 
 	@Override
-	public int process(TermFrequencyCounter counter)
+	public Token process(Token token)
 	{
-		Set<Token> issueTokensCopy = new HashSet<Token>(counter.getTokens());
-		Iterator<Token> tokens = issueTokensCopy.iterator();
-		int stemmedElements = 0;
-		while(tokens.hasNext())
-		{
-			final Token token = tokens.next();
-			setCurrentToken(token);
-			stem();
-			final Token stemmedToken = getCurrentToken();
-			if(!token.equals(stemmedToken))
-			{
-				counter.change(token, stemmedToken);
-				stemmedElements++;
-			}
-		}
-		
-		return stemmedElements;
+		setCurrentToken(token);
+		stem();
+		return getCurrentToken();
 	}
 }

--- a/src/duplicatesearcher/processing/TokenProcessor.java
+++ b/src/duplicatesearcher/processing/TokenProcessor.java
@@ -11,10 +11,9 @@ import duplicatesearcher.analysis.frequency.TermFrequencyCounter;
 public interface TokenProcessor
 {
 	/**
-	 * 
-	 * @param tokens a {@link TermFrequencyCounter} containing instances of
-	 * {@link Token} which will be modified.
-	 * @return the number of elements that were modified.
+	 * Process a {@link Token}.
+	 * @param token input that will be processed.
+	 * @return a processed version of the original Token that was given as input.
 	 */
-	int process(final TermFrequencyCounter tokens);
+	Token process(final Token token);
 }

--- a/src/duplicatesearcher/processing/spellcorrecting/SpellCorrector.java
+++ b/src/duplicatesearcher/processing/spellcorrecting/SpellCorrector.java
@@ -6,16 +6,12 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.SortedMap;
 
 import duplicatesearcher.Token;
-import duplicatesearcher.analysis.frequency.TermFrequencyCounter;
 import duplicatesearcher.datastructures.BKtree;
 import duplicatesearcher.processing.TokenProcessor;
 import duplicatesearcher.processing.Tokenizer;

--- a/src/duplicatesearcher/processing/spellcorrecting/SpellCorrector.java
+++ b/src/duplicatesearcher/processing/spellcorrecting/SpellCorrector.java
@@ -24,7 +24,6 @@ import duplicatesearcher.processing.Tokenizer;
 public class SpellCorrector implements TokenProcessor {
 	private final HashSet<Token> dictionary;
 	private final BKtree tree;
-	private final Map<Token, Token> corrections = new HashMap<Token, Token>();
 	
 	public SpellCorrector(final File dictionaryFile) throws IOException {
 		this.dictionary = new HashSet<Token>();
@@ -52,24 +51,10 @@ public class SpellCorrector implements TokenProcessor {
 	}
 	
 	@Override
-	public int process(final TermFrequencyCounter tokens){
-		Set<Token> issueTokensCopy = new HashSet<Token>(tokens.getTokens());
-		int spellCorrections = 0;
-		
-		for(Token token : issueTokensCopy)
-		{
-			if(!isMisspelled(token))
-				continue;
-			Token tokenSpellCorrected = correctWord(token);
-			if(!token.equals(tokenSpellCorrected))
-			{
-				tokens.change(token, tokenSpellCorrected);
-				spellCorrections++;
-				corrections.put(token, tokenSpellCorrected);
-			}
-		}
-		
-		return spellCorrections;
+	public Token process(final Token token){
+		if(!isMisspelled(token))
+			return token;
+		return correctWord(token);
 	}
 	
 	/**
@@ -85,7 +70,7 @@ public class SpellCorrector implements TokenProcessor {
 	}
 	
 	public Token correctWord(CharSequence textSubject){
-		final int threshold = (int) Math.round(Math.log(textSubject.length()-0.2)); 
+		final int threshold = (int) Math.round(Math.log(textSubject.length()-0.6)); 
 		SortedMap<Integer, List<CharSequence>> foundWords = tree.find(textSubject, threshold);
 		return tokenFrom(foundWords, textSubject);
 	}
@@ -94,7 +79,6 @@ public class SpellCorrector implements TokenProcessor {
 		SortedMap<Integer, List<CharSequence>>foundWords = tree.find(textSubject, threshold);
 		return tokenFrom(foundWords, textSubject);
 	}
-
 
 	private Token tokenFrom(SortedMap<Integer, List<CharSequence>> foundWords, CharSequence textSubject)
 	{
@@ -105,10 +89,4 @@ public class SpellCorrector implements TokenProcessor {
 		
 		return new Token(textSubject);
 	}
-	
-	public Map<Token, Token> getCorrections()
-	{
-		return corrections;
-	}
-
 }

--- a/src/duplicatesearcher/processing/spellcorrecting/SpellCorrector.java
+++ b/src/duplicatesearcher/processing/spellcorrecting/SpellCorrector.java
@@ -70,7 +70,10 @@ public class SpellCorrector implements TokenProcessor {
 	}
 	
 	public Token correctWord(CharSequence textSubject){
-		final int threshold = (int) Math.round(Math.log(textSubject.length()-0.6)); 
+		final int threshold = textSubject.length()/5;
+		if(threshold == 0)
+			return new Token(textSubject);
+		
 		SortedMap<Integer, List<CharSequence>> foundWords = tree.find(textSubject, threshold);
 		return tokenFrom(foundWords, textSubject);
 	}

--- a/src/duplicatesearcher/processing/stoplists/StopList.java
+++ b/src/duplicatesearcher/processing/stoplists/StopList.java
@@ -10,7 +10,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import duplicatesearcher.Token;
-import duplicatesearcher.analysis.frequency.TermFrequencyCounter;
 import duplicatesearcher.processing.TokenProcessor;
 import duplicatesearcher.processing.Tokenizer;
 
@@ -37,20 +36,12 @@ public class StopList implements TokenProcessor
 		}
 	}
 
-	/**
-	 * Removes all tokens that are present in the stop word list from the given
-	 * input set.
-	 * 
-	 * @param tokens the {@link TermFrequencyCounter} from which stop words will
-	 * be removed.
-	 * @return the amount of words that were removed.
-	 */
 	@Override
-	public int process(TermFrequencyCounter tokens)
+	public Token process(Token token)
 	{
-		final int sizeBefore = tokens.size();
-		tokens.getTokens().removeAll(stopWords);
-		return sizeBefore - tokens.size();
+		if(!stopWords.contains(token))
+			return token;
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
A general overhaul to IssueProcessor and performance improvements has been made. interface methodTokenProcessor.process() now operates on single Tokens rather than TermFrequencyCounter. This has in turn enabled caching of processing of tokens, so a distinct token never has to processed more than once. The performance gain of this is somewhere between 7 - 16%.
- No cache
  - golang/go --> PT10M12.64S
  - telegramdesktop/tdesktop --> PT3M23.871S
- Cached
  - golang/go --> PT9M32.28S
  - telegramdesktop/tdesktop --> PT2M51.797S

After some profiling, the current bottleneck right now seems to be LevenshteinDistance.unlimitedCompare() which accounts for roughly 3/4 of the execution time during the processing of issues when spell correction is done.

This closes #39.
